### PR TITLE
fix: prevent latent panics in day 6 and day 17

### DIFF
--- a/crates/year_2024/src/day_06.rs
+++ b/crates/year_2024/src/day_06.rs
@@ -23,13 +23,17 @@ enum Result {
     Cyclic,
 }
 
-fn next_step(map: &Grid<char>, pos: (i64, i64), dir: Direction) -> Direction {
-    let next = pos + dir;
-    if map.get(next.0, next.1) == Some(&'#') {
-        next_step(map, pos, dir.clockwise())
-    } else {
-        dir
+fn next_step(map: &Grid<char>, pos: (i64, i64), mut dir: Direction) -> Direction {
+    // Turn clockwise until the way ahead is clear. Bail after a full rotation so
+    // a guard boxed in on all four sides can't recurse/loop forever.
+    for _ in 0..4 {
+        let next = pos + dir;
+        if map.get(next.0, next.1) != Some(&'#') {
+            return dir;
+        }
+        dir = dir.clockwise();
     }
+    dir
 }
 
 fn get_pos<T: TryFrom<usize>>(map: &Grid<char>) -> (T, T) {

--- a/crates/year_2024/src/day_17.rs
+++ b/crates/year_2024/src/day_17.rs
@@ -49,28 +49,34 @@ fn read_input(input: &str) -> ((u64, u64, u64), Vec<OpCode>) {
     .unwrap()
 }
 
+// The combo operand is only decoded for the instructions that use it. Decoding
+// it eagerly would panic on the reserved value 7, which is a legal *literal*
+// operand for `bxl`/`jnz`/`bxc` (e.g. the common `bxl 7`).
+fn combo_operand(literal_operand: u64, reg: &Registers) -> u64 {
+    match literal_operand {
+        0..4 => literal_operand,
+        4 => reg.a,
+        5 => reg.b,
+        6 => reg.c,
+        _ => unreachable!(),
+    }
+}
+
 fn computer(mut reg: Registers, instructions: &[OpCode]) -> Vec<u8> {
     let mut out = Vec::new();
     let mut instr_ptr = 0;
     while instr_ptr + 1 < instructions.len() {
         let opcode = instructions[instr_ptr];
         let literal_operand = instructions[instr_ptr + 1] as u64;
-        let combo_operand = match literal_operand {
-            0..4 => literal_operand,
-            4 => reg.a,
-            5 => reg.b,
-            6 => reg.c,
-            _ => unreachable!(),
-        };
         match opcode {
             OpCode::Adv => {
-                reg.a /= 2u64.pow(combo_operand.try_into().unwrap());
+                reg.a /= 2u64.pow(combo_operand(literal_operand, &reg).try_into().unwrap());
             }
             OpCode::Bxl => {
                 reg.b = reg.b.bitxor(literal_operand);
             }
             OpCode::Bst => {
-                reg.b = combo_operand & 7;
+                reg.b = combo_operand(literal_operand, &reg) & 7;
             }
             OpCode::Jnz => {
                 if reg.a != 0 {
@@ -82,13 +88,17 @@ fn computer(mut reg: Registers, instructions: &[OpCode]) -> Vec<u8> {
                 reg.b = reg.c.bitxor(reg.b);
             }
             OpCode::Out => {
-                out.push((combo_operand & 7).try_into().unwrap());
+                out.push(
+                    (combo_operand(literal_operand, &reg) & 7)
+                        .try_into()
+                        .unwrap(),
+                );
             }
             OpCode::Bdv => {
-                reg.b = reg.a / 2u64.pow(combo_operand.try_into().unwrap());
+                reg.b = reg.a / 2u64.pow(combo_operand(literal_operand, &reg).try_into().unwrap());
             }
             OpCode::Cdv => {
-                reg.c = reg.a / 2u64.pow(combo_operand.try_into().unwrap());
+                reg.c = reg.a / 2u64.pow(combo_operand(literal_operand, &reg).try_into().unwrap());
             }
         }
         instr_ptr += 2;


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Two latent panics surfaced in the [review (#23)](https://github.com/henryiii/aoc2024/issues/23).

### Day 6 — unbounded recursion (`next_step`)
`next_step` recursed on `dir.clockwise()` with no base case, so a guard boxed in by `#` on all four sides recurses forever. This is reachable in part 2 when the placed obstacle encloses the guard. Now it turns at most a full rotation and returns.

### Day 17 — eager combo-operand decode (`computer`)
The combo operand was decoded for *every* instruction, with `_ => unreachable!()` for the reserved value 7. But 7 is a perfectly legal **literal** operand for `bxl`/`jnz`/`bxc` (e.g. the very common `bxl 7`), so those programs panicked. The combo operand is now decoded lazily, only inside the arms that actually use it (`adv`/`bst`/`out`/`bdv`/`cdv`).

Both days' sample tests still pass; `cargo clippy -- -D warnings` is clean.

Refs #23.