### PR TITLE
perf: cache and hoist repeated work in days 3, 19, 22, 24

### DIFF
--- a/crates/year_2024/src/day_03.rs
+++ b/crates/year_2024/src/day_03.rs
@@ -8,6 +8,8 @@ This has us find and run very simple instructions embedded in junk. The second
 part has state.
 */
 
+use std::sync::LazyLock;
+
 use regex::Regex;
 
 enum Instruction {
@@ -16,9 +18,13 @@ enum Instruction {
     Mul(u64, u64),
 }
 
+static MUL: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"mul\(([[:digit:]]+),([[:digit:]]+)\)").unwrap());
+static MUL_DO_DONT: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"mul\(([[:digit:]]+),([[:digit:]]+)\)|do\(\)|don't\(\)").unwrap());
+
 pub fn solution_a(input: &str) -> u64 {
-    let reg = Regex::new(r"mul\(([[:digit:]]+),([[:digit:]]+)\)").unwrap();
-    reg.captures_iter(input)
+    MUL.captures_iter(input)
         .map(|cap| {
             let a: u64 = cap[1].parse().unwrap();
             let b: u64 = cap[2].parse().unwrap();
@@ -28,8 +34,8 @@ pub fn solution_a(input: &str) -> u64 {
 }
 
 pub fn solution_b(input: &str) -> u64 {
-    let reg = Regex::new(r"mul\(([[:digit:]]+),([[:digit:]]+)\)|do\(\)|don't\(\)").unwrap();
-    reg.captures_iter(input)
+    MUL_DO_DONT
+        .captures_iter(input)
         .map(|cap| match &cap[0] {
             "do()" => Instruction::Do,
             "don't()" => Instruction::Dont,

--- a/crates/year_2024/src/day_19.rs
+++ b/crates/year_2024/src/day_19.rs
@@ -17,31 +17,31 @@ use cached::cached;
 
 type Int = usize;
 
-fn read_input(input: &str) -> (Vec<Vec<char>>, Vec<Vec<char>>) {
+fn read_input(input: &str) -> (Vec<String>, Vec<String>) {
     use aoc_parse::{parser, prelude::*};
 
     parser!(
-        section(line(repeat_sep(alpha+, ", ")))
-        section(lines(alpha+))
+        section(line(repeat_sep(string(alpha+), ", ")))
+        section(lines(string(alpha+)))
     )
     .parse(input)
     .unwrap()
 }
 
-#[cached(key = "Vec<char>", convert = "{Vec::from(line)}")]
-fn has_match(patterns: &[Vec<char>], line: &[char]) -> bool {
+#[cached(key = "String", convert = "{line.to_owned()}")]
+fn has_match(patterns: &[String], line: &str) -> bool {
     patterns.iter().any(|pattern| {
-        line.strip_prefix(&pattern[..])
+        line.strip_prefix(pattern.as_str())
             .is_some_and(|slice| slice.is_empty() || has_match(patterns, slice))
     })
 }
 
-#[cached(key = "Vec<char>", convert = "{Vec::from(line)}")]
-fn count_match(patterns: &[Vec<char>], line: &[char]) -> Int {
+#[cached(key = "String", convert = "{line.to_owned()}")]
+fn count_match(patterns: &[String], line: &str) -> Int {
     patterns
         .iter()
         .map(|pattern| {
-            line.strip_prefix(&pattern[..]).map_or(0, |slice| {
+            line.strip_prefix(pattern.as_str()).map_or(0, |slice| {
                 if slice.is_empty() {
                     1
                 } else {

--- a/crates/year_2024/src/day_22.rs
+++ b/crates/year_2024/src/day_22.rs
@@ -10,9 +10,12 @@ other code a bit, and realizing that a histogram was much more performant at the
 cost of some memory.
 */
 
-// 2284 is too high
-
 use itertools::Itertools;
+
+/// Each price delta lands in `-9..=9`, i.e. 19 buckets; a window of four deltas
+/// indexes a flat histogram of `19^4` entries.
+const BUCKETS: usize = 19;
+const HIST_SIZE: usize = BUCKETS.pow(4);
 
 fn read_input(input: &str) -> Vec<u64> {
     use aoc_parse::{parser, prelude::*};
@@ -58,8 +61,8 @@ pub fn solution_a(input: &str) -> u64 {
 pub fn solution_b(input: &str) -> u16 {
     let nums = read_input(input);
     let vals = expand(&nums);
-    let mut totals = vec![0u16; 19usize.pow(4)];
-    let mut seen = vec![false; 19usize.pow(4)];
+    let mut totals = vec![0u16; HIST_SIZE];
+    let mut seen = vec![false; HIST_SIZE];
 
     for vv in vals {
         seen.fill(false);
@@ -68,7 +71,7 @@ pub fn solution_b(input: &str) -> u16 {
             let b = usize::from(*cc + 9 - *bb);
             let c = usize::from(*dd + 9 - *cc);
             let d = usize::from(*ee + 9 - *dd);
-            let idx = a * 19usize.pow(3) + b * 19usize.pow(2) + c * 19usize.pow(1) + d;
+            let idx = ((a * BUCKETS + b) * BUCKETS + c) * BUCKETS + d;
             if !seen[idx] {
                 totals[idx] += u16::from(*ee);
                 seen[idx] = true;

--- a/crates/year_2024/src/day_24.rs
+++ b/crates/year_2024/src/day_24.rs
@@ -46,19 +46,21 @@ fn read_input(input: &str) -> (Vec<(String, bool)>, Vec<(String, String, String,
 fn lookup_value(
     key: &str,
     cons: &HashMap<&str, (&str, Instruction, &str)>,
-    inputs: &[(String, bool)],
+    cache: &mut HashMap<String, bool>,
 ) -> bool {
-    if let Some((_, val)) = inputs.iter().find(|(k, _)| k == key) {
-        return *val;
+    if let Some(&val) = cache.get(key) {
+        return val;
     }
     let (a, instr, b) = cons[key];
-    let a = lookup_value(a, cons, inputs);
-    let b = lookup_value(b, cons, inputs);
-    match instr {
+    let a = lookup_value(a, cons, cache);
+    let b = lookup_value(b, cons, cache);
+    let val = match instr {
         Instruction::And => a & b,
         Instruction::Or => a | b,
         Instruction::Xor => a ^ b,
-    }
+    };
+    cache.insert(key.to_owned(), val);
+    val
 }
 
 fn setup(
@@ -79,10 +81,11 @@ fn compute_inputs(
     cons: &HashMap<&str, (&str, Instruction, &str)>,
     inputs: &[(String, bool)],
 ) -> Int {
+    let mut cache: HashMap<String, bool> = inputs.iter().map(|(k, v)| (k.clone(), *v)).collect();
     cons.keys()
         .filter(|k| k.starts_with('z'))
         .sorted()
-        .map(|&x| lookup_value(x, cons, inputs))
+        .map(|&x| lookup_value(x, cons, &mut cache))
         .rev()
         .fold(0, |acc, x| acc * 2 + usize::from(x))
 }
@@ -102,11 +105,12 @@ pub fn solution_b(input: &str) -> String {
         .max()
         .unwrap();
     let max_output = max_input + 1;
+    let last_output = format!("z{max_output}");
     let mut bad_connections = HashSet::new();
     // Checking rules for a ripple carry adder
     // Every output must be connected via an XOR (except the last one, which is the final carry)
     bad_connections.extend(cons.iter().filter(|&(out, (_, op, _))| {
-        out.starts_with('z') && *op != Instruction::Xor && *out != format!("z{max_output}")
+        out.starts_with('z') && *op != Instruction::Xor && *out != last_output
     }));
     // Every XOR must connect to an input or an output
     bad_connections.extend(cons.iter().filter(|&(out, (in1, op, in2))| {
@@ -125,7 +129,7 @@ pub fn solution_b(input: &str) -> String {
             && !matches!(*in2, "x00" | "y00")
     }));
     // Make a collection of all OR inputs
-    let adder_ors: HashSet<_> = cons
+    let or_inputs: HashSet<_> = cons
         .iter()
         .filter(|&(_, (_, op, _))| *op == Instruction::Or)
         .flat_map(|(_, (in1, _, in2))| [in1, in2])
@@ -135,19 +139,13 @@ pub fn solution_b(input: &str) -> String {
         *op == Instruction::And
             && !matches!(*in1, "x00" | "y00")
             && !matches!(*in2, "x00" | "y00")
-            && !adder_ors.contains(out)
+            && !or_inputs.contains(out)
     }));
 
-    // Make a collection of all OR inputs
-    let all_ors: HashSet<_> = cons
-        .iter()
-        .filter(|&(_, (_, op, _))| *op == Instruction::Or)
-        .flat_map(|(_, (in1, _, in2))| [in1, in2])
-        .collect();
-    // ORs can only be feed by ANDs
+    // ORs can only be fed by ANDs
     bad_connections.extend(
         cons.iter()
-            .filter(|&(out, (_, op, _))| *op != Instruction::And && all_ors.contains(out)),
+            .filter(|&(out, (_, op, _))| *op != Instruction::And && or_inputs.contains(out)),
     );
 
     bad_connections


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Performance items from the [review (#23)](https://github.com/henryiii/aoc2024/issues/23). All sample tests pass and `cargo clippy -- -D warnings` is clean.

- **Day 3** — `Regex::new` was recompiled on every call; the two patterns are now `LazyLock` statics compiled once.
- **Day 19** — the memoization cache was keyed on `Vec<char>`, allocating a fresh char-vector per lookup (even on hits). Switched the whole day to `&str`/`String`, so keys are bytes rather than 4-byte `char`s (and the parsing is more idiomatic).
- **Day 22** — `19usize.pow(k)` was recomputed inside the hot per-window loop; hoisted to `const`s and built the index with a Horner-style fold. Removed a leftover `// 2284 is too high` scratch comment.
- **Day 24** — `lookup_value` did an O(n) `inputs.iter().find` per leaf *and* re-evaluated shared sub-circuits (worst-case exponential). It now memoizes into a `HashMap`. Also de-duplicated the two byte-identical OR-input set computations and hoisted the per-iteration `format!("z{max_output}")` allocation out of the filter closure.

Refs #23.