### PR TITLE
refactor: use repeat_n and combinations iterators

### DIFF
--- a/crates/year_2024/src/day_08.rs
+++ b/crates/year_2024/src/day_08.rs
@@ -29,8 +29,7 @@ fn solution(map: &Grid<char>, range: Range<usize>) -> usize {
             .collect();
 
         // Every pair of nodes
-        locs.iter().combinations(2).for_each(|v| {
-            let (&a, &b) = v.iter().collect_tuple().unwrap();
+        locs.iter().array_combinations().for_each(|[&a, &b]| {
             let dir = (b.0 - a.0, b.1 - a.1);
             for n in range.clone() {
                 let n: i64 = n.try_into().unwrap();

--- a/crates/year_2024/src/day_09.rs
+++ b/crates/year_2024/src/day_09.rs
@@ -42,8 +42,8 @@ fn expand_filesystem(data: &[Block]) -> Vec<Option<usize>> {
             block
                 .id_size
                 .iter()
-                .flat_map(|&(id, size)| [Some(id)].repeat(size).into_iter())
-                .chain([None].repeat(block.empty))
+                .flat_map(|&(id, size)| std::iter::repeat_n(Some(id), size))
+                .chain(std::iter::repeat_n(None, block.empty))
         })
         .collect()
 }

--- a/crates/year_2024/src/day_21.rs
+++ b/crates/year_2024/src/day_21.rs
@@ -76,14 +76,14 @@ impl KeyPad {
         let new_pos = self.pos(target);
 
         let vert_chars = if cur_pos.0 < new_pos.0 {
-            iter::repeat('v').take(new_pos.0 - cur_pos.0)
+            iter::repeat_n('v', new_pos.0 - cur_pos.0)
         } else {
-            iter::repeat('^').take(cur_pos.0 - new_pos.0)
+            iter::repeat_n('^', cur_pos.0 - new_pos.0)
         };
         let horiz_chars = if cur_pos.1 < new_pos.1 {
-            iter::repeat('>').take(new_pos.1 - cur_pos.1)
+            iter::repeat_n('>', new_pos.1 - cur_pos.1)
         } else {
-            iter::repeat('<').take(cur_pos.1 - new_pos.1)
+            iter::repeat_n('<', cur_pos.1 - new_pos.1)
         };
 
         if cur_pos.0 == new_pos.0 {

--- a/crates/year_2024/src/day_23.rs
+++ b/crates/year_2024/src/day_23.rs
@@ -35,7 +35,7 @@ fn intercon<'a>(graph: &UnGraphMap<&'a str, ()>) -> HashSet<Vec<&'a str>> {
         .nodes()
         .flat_map(|node| {
             let neighbors = graph.neighbors(node);
-            neighbors.permutations(2).filter_map(move |v| {
+            neighbors.combinations(2).filter_map(move |v| {
                 let (a, b) = v.into_iter().collect_tuple().unwrap();
                 if graph.contains_edge(a, b) {
                     let mut res = vec![node, a, b];


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Modernization items from the [review (#23)](https://github.com/henryiii/aoc2024/issues/23). All sample tests pass and `cargo clippy -- -D warnings` is clean.

- **Day 8** — `combinations(2)` + `collect_tuple().unwrap()` round-tripped each pair through a `Vec`. Replaced with `array_combinations()` destructured as `[&a, &b]` (no per-pair allocation; also `tuple_combinations` is deprecated in itertools 0.15).
- **Day 9** — `[Some(id)].repeat(size).into_iter()` and `[None].repeat(n)` allocated a `Vec` per run; now `std::iter::repeat_n(...)` (stable since 1.82).
- **Day 21** — `iter::repeat(c).take(n)` → `iter::repeat_n(c, n)`.
- **Day 23** — `permutations(2)` yields each unordered pair twice; `combinations(2)` does each once, halving the triangle scan (the result set de-dupes either way).

Refs #23.