### PR TITLE
fix: tighten correctness in days 5, 13, 17

### DIFF
--- a/crates/year_2024/src/day_05.rs
+++ b/crates/year_2024/src/day_05.rs
@@ -36,7 +36,10 @@ fn compare_rules(rules: &HashSet<(u64, u64)>, a: u64, b: u64) -> std::cmp::Order
 
 /// Returns true if the order follows the rules.
 fn in_order(rules: &HashSet<(u64, u64)>, order: &[u64]) -> bool {
-    order.is_sorted_by(|&a, &b| compare_rules(rules, a, b) == std::cmp::Ordering::Less)
+    // `is_sorted_by`'s predicate asks "is a ordered before-or-equal b". Pairs
+    // with no rule compare `Equal`, which must count as in order, so test
+    // against `Greater` rather than `== Less`.
+    order.is_sorted_by(|&a, &b| compare_rules(rules, a, b) != std::cmp::Ordering::Greater)
 }
 
 /// Reorders the order to follow the rules. Returns a new ordered vector.

--- a/crates/year_2024/src/day_13.rs
+++ b/crates/year_2024/src/day_13.rs
@@ -34,6 +34,11 @@ impl Machine {
     fn chk_analytical(&self) -> Option<(i64, i64)> {
         let det = self.a.0 * self.b.1 - self.a.1 * self.b.0;
         if det == 0 {
+            // Colinear buttons. Brute-force the feasible range, but guard the
+            // bounds against a divide-by-zero when a button has a zero axis.
+            if self.b.1 == 0 || self.a.0 == 0 {
+                return None;
+            }
             let min = self.prize.1 / self.b.1;
             let max = self.prize.0 / self.a.0;
             return self.chk_all(min..=max);

--- a/crates/year_2024/src/day_17.rs
+++ b/crates/year_2024/src/day_17.rs
@@ -34,16 +34,17 @@ struct Registers {
     c: u64,
 }
 
-fn read_input(input: &str) -> ((u64, u64, u64), Vec<OpCode>) {
+fn read_input(input: &str) -> (Registers, Vec<OpCode>) {
     use aoc_parse::{parser, prelude::*};
 
     parser!(
-        section(
+        regs:section(
             line("Register A: " u64)
             line("Register B: " u64)
             line("Register C: " u64)
         )
-        section("Program: " repeat_sep(a:u8 => OpCode::try_from(a).unwrap(), ","))
+        prog:section("Program: " repeat_sep(a:u8 => OpCode::try_from(a).unwrap(), ","))
+        => (Registers::new(regs.0, regs.1, regs.2), prog)
     )
     .parse(input)
     .unwrap()
@@ -98,46 +99,30 @@ fn computer(mut reg: Registers, instructions: &[OpCode]) -> Vec<u8> {
 
 pub fn solution_a(input: &str) -> String {
     let (reg, instructions) = read_input(input);
-    let reg = Registers::new(reg.0, reg.1, reg.2);
     let out = computer(reg, &instructions);
     out.iter().join(",")
 }
 
 pub fn solution_b(input: &str) -> u64 {
     let (reg, instructions) = read_input(input);
-    let expected_out = instructions.iter().map(|x| *x as u8).collect_vec();
-    let size: u32 = expected_out.len().try_into().unwrap();
+    let expected: Vec<u8> = instructions.iter().map(|x| *x as u8).collect();
 
-    // Shortcut for simple runs
-    if size < 7 {
-        return (0..8u64.pow(size))
-            .find(|val| computer(Registers::new(*val, reg.1, reg.2), &instructions) == expected_out)
-            .unwrap();
+    // The program reads register A three bits at a time from the bottom up,
+    // emitting one output per group, so the i-th output is fixed by the octit
+    // at position i. Build A from the top octit down, keeping every prefix whose
+    // output matches the corresponding suffix of the program, then take the
+    // smallest. (The previous version locked in the first matching octit, which
+    // missed value 0 and wasn't general.)
+    let mut candidates = vec![0u64];
+    for i in (0..expected.len()).rev() {
+        let want = &expected[i..];
+        candidates = candidates
+            .iter()
+            .flat_map(|&acc| (0..8).map(move |octit| acc * 8 + octit))
+            .filter(|&a| computer(Registers::new(a, reg.b, reg.c), &instructions) == want)
+            .collect();
     }
-
-    // Try to find the value, assuming each value is locked in place one it prints
-    let mut val = 0;
-    for i in 0..expected_out.len() {
-        val *= 8;
-        for _ in 0..8 {
-            val += 1;
-            let reg = Registers::new(val, reg.1, reg.2);
-            let out = computer(reg, &instructions);
-            if *out.first().unwrap() == expected_out[expected_out.len() - 1 - i] {
-                break;
-            }
-        }
-    }
-    // The assumption above is too strict for the final value due to the two
-    // 8-bit registers
-    for i in (val - 0o77)..=(val + 0o77) {
-        let reg = Registers::new(i, reg.1, reg.2);
-        let out = computer(reg, &instructions);
-        if out == expected_out {
-            return i;
-        }
-    }
-    unreachable!();
+    candidates.into_iter().min().unwrap()
 }
 
 pub fn main(_: bool) {


### PR DESCRIPTION
:robot: _AI text below_ :robot:

The lower-confidence robustness items from the [review (#23)](https://github.com/henryiii/aoc2024/issues/23). All sample tests pass and `cargo clippy -- -D warnings` is clean.

- **Day 5** — `in_order` used `compare_rules(..) == Less` as the `is_sorted_by` predicate. That predicate means "is a ordered before-or-equal b", but pairs with no rule compare `Equal` and were wrongly treated as out of order. Now tests `!= Greater`.
- **Day 13** — the colinear (`det == 0`) branch divided by `b.1` and `a.0` unconditionally, panicking when a button has a zero axis (the module doc already notes this case wasn't handled). Guards the bounds and returns `None`.
- **Day 17** — the part-2 search locked in the first matching octit, so it never tried `0` and wasn't general (the doc admits it "just happens to work"). Replaced with the standard reverse construction (build A from the top octit down, keep every prefix whose output matches the program suffix, take the smallest). Validated against the part-2 sample (117440); the real input is gitignored so it can't be exercised in CI. Also `read_input` now returns `Registers` directly.

> Note: this touches `day_17.rs` in different functions (`read_input`/`solution_a`/`solution_b`) than #24 (`computer`), so the two PRs apply cleanly in either order.

Refs #23.