### PR TITLE
refactor: iterative flood fill (day 12) and cheaper scan (day 14)

### DIFF
--- a/crates/year_2024/src/day_12.rs
+++ b/crates/year_2024/src/day_12.rs
@@ -19,22 +19,21 @@ use strum::IntoEnumIterator;
 use aoc::grid::{Direction, read_char};
 
 fn find_region(seen: &mut Grid<bool>, map: &Grid<char>, start: (i64, i64)) -> Vec<(i64, i64)> {
-    *seen.get_mut(start.0, start.1).unwrap() = true;
     let ch = map.get(start.0, start.1).unwrap();
-    std::iter::once(start)
-        .chain(
-            Direction::iter()
-                .filter_map(|dir| {
-                    let pos = start + dir;
-                    if seen.get(pos.0, pos.1) == Some(&false) && map.get(pos.0, pos.1) == Some(ch) {
-                        Some(find_region(seen, map, pos))
-                    } else {
-                        None
-                    }
-                })
-                .flatten(),
-        )
-        .collect()
+    let mut region = Vec::new();
+    let mut stack = vec![start];
+    *seen.get_mut(start.0, start.1).unwrap() = true;
+    while let Some(pos) = stack.pop() {
+        region.push(pos);
+        for dir in Direction::iter() {
+            let next = pos + dir;
+            if seen.get(next.0, next.1) == Some(&false) && map.get(next.0, next.1) == Some(ch) {
+                *seen.get_mut(next.0, next.1).unwrap() = true;
+                stack.push(next);
+            }
+        }
+    }
+    region
 }
 
 fn get_edges(
@@ -48,16 +47,16 @@ fn get_edges(
 }
 
 fn remove_contiguous(sides: &mut HashSet<(Direction, i64, i64)>, start: (Direction, i64, i64)) {
-    let a = (start.1, start.2) + start.0.clockwise();
-    let b = (start.1, start.2) + start.0.counter_clockwise();
-
-    if sides.contains(&(start.0, a.0, a.1)) {
-        sides.remove(&(start.0, a.0, a.1));
-        remove_contiguous(sides, (start.0, a.0, a.1));
-    }
-    if sides.contains(&(start.0, b.0, b.1)) {
-        sides.remove(&(start.0, b.0, b.1));
-        remove_contiguous(sides, (start.0, b.0, b.1));
+    let mut stack = vec![start];
+    while let Some(edge) = stack.pop() {
+        let pos = (edge.1, edge.2);
+        for along in [edge.0.clockwise(), edge.0.counter_clockwise()] {
+            let next = pos + along;
+            let neighbor = (edge.0, next.0, next.1);
+            if sides.remove(&neighbor) {
+                stack.push(neighbor);
+            }
+        }
     }
 }
 
@@ -73,7 +72,9 @@ fn get_sides(region: &HashSet<(i64, i64)>) -> usize {
     i
 }
 
-pub fn solution_a(input: &str) -> usize {
+/// Sum `area * perimeter` over every region, with `perimeter` measuring either
+/// fence segments (part a) or straight sides (part b).
+fn solve(input: &str, perimeter: impl Fn(&HashSet<(i64, i64)>) -> usize) -> usize {
     let map = read_char(input);
     let mut seen = Grid::new(map.rows(), map.cols());
     map.indexed_iter()
@@ -83,24 +84,17 @@ pub fn solution_a(input: &str) -> usize {
             }
             let start = (x.try_into().unwrap(), y.try_into().unwrap());
             let region: HashSet<_> = find_region(&mut seen, &map, start).into_iter().collect();
-            Some((region.len(), get_edges(&region).count()))
+            Some(region.len() * perimeter(&region))
         })
-        .fold(0, |acc, (a, p)| acc + a * p)
+        .sum()
+}
+
+pub fn solution_a(input: &str) -> usize {
+    solve(input, |region| get_edges(region).count())
 }
 
 pub fn solution_b(input: &str) -> usize {
-    let map = read_char(input);
-    let mut seen = Grid::new(map.rows(), map.cols());
-    map.indexed_iter()
-        .filter_map(|((x, y), _)| {
-            if seen[(x, y)] {
-                return None;
-            }
-            let start = (x.try_into().unwrap(), y.try_into().unwrap());
-            let region: HashSet<_> = find_region(&mut seen, &map, start).into_iter().collect();
-            Some((region.len(), get_sides(&region)))
-        })
-        .fold(0, |acc, (a, p)| acc + a * p)
+    solve(input, get_sides)
 }
 
 pub fn main(_: bool) {

--- a/crates/year_2024/src/day_14.rs
+++ b/crates/year_2024/src/day_14.rs
@@ -81,11 +81,18 @@ fn solution_b_full(input: &str, vis: bool) -> usize {
             *pos = (*pos + *vel).rem_euclid(&size);
         }
 
+        // The picture appears the first time no two robots share a cell. Detect
+        // that while placing them instead of rescanning the whole grid after.
         grid.fill(0);
+        let mut unique = true;
         for (pos, _) in &robots {
             grid[*pos] += 1;
+            if grid[*pos] > 1 {
+                unique = false;
+                break;
+            }
         }
-        if grid.iter().all(|x| *x <= 1) {
+        if unique {
             if vis {
                 vis_grid(&grid);
             }


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Grid/region items from the [review (#23)](https://github.com/henryiii/aoc2024/issues/23). All sample tests pass and `cargo clippy -- -D warnings` is clean.

- **Day 12** — `find_region` and `remove_contiguous` were recursive, recursing as deep as a region's area / an edge's length (thousands of frames on the real input) and risking stack overflow. Both are now explicit worklist loops. The near-identical `solution_a`/`solution_b` collapse into one `solve` helper parameterized by the perimeter function, with `.sum()` replacing the manual `fold`.
- **Day 14** — the part-2 loop refilled the grid and then rescanned it entirely with `iter().all(|x| *x <= 1)` every step. Now the collision check happens inline while placing robots, breaking on the first shared cell.

Deferred from the review (noted for transparency): day 15 `push_vertical` dedup-hoist (correctness-sensitive, marginal gain) and day 16's part-2 perf rewrite (large reverse-Dijkstra change) — happy to do those as their own PRs if wanted.

Refs #23.