### PR TITLE
refactor: generate python bindings; tidy geom and day 20

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1272,7 +1272,9 @@ dependencies = [
 name = "python_2024"
 version = "0.1.0"
 dependencies = [
+ "paste",
  "pyo3",
+ "seq-macro",
  "year_2024",
 ]
 

--- a/crates/aoc/src/geom.rs
+++ b/crates/aoc/src/geom.rs
@@ -41,17 +41,14 @@ impl<T: Euclid> Point<T> {
 impl<T, V> Index<Point<V>> for Grid<T>
 where
     usize: TryFrom<V>,
+    <usize as TryFrom<V>>::Error: Debug,
 {
     type Output = T;
 
     fn index(&self, pos: Point<V>) -> &Self::Output {
         &self[(
-            usize::try_from(pos.1)
-                .ok()
-                .expect("Row must not be negative"),
-            usize::try_from(pos.0)
-                .ok()
-                .expect("Column must not be negative"),
+            usize::try_from(pos.1).expect("Row must not be negative"),
+            usize::try_from(pos.0).expect("Column must not be negative"),
         )]
     }
 }
@@ -64,8 +61,27 @@ where
 {
     fn index_mut(&mut self, pos: Point<V>) -> &mut Self::Output {
         &mut self[(
-            usize::try_from(pos.1).unwrap(),
-            usize::try_from(pos.0).unwrap(),
+            usize::try_from(pos.1).expect("Row must not be negative"),
+            usize::try_from(pos.0).expect("Column must not be negative"),
         )]
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Point;
+    use grid::grid;
+
+    // The crate disables doctests (the README is included as crate docs), so the
+    // indexing example lives here as a real test instead.
+    #[test]
+    fn index_by_point() {
+        let mut g = grid![[1, 2][3, 4]];
+        let p: Point<i64> = Point(0, 0);
+        assert_eq!(g[p], 1);
+        assert_eq!(g[Point(1i64, 0)], 2);
+        assert_eq!(g[Point(0i64, 1)], 3);
+        g[Point(1i64, 1)] = 9;
+        assert_eq!(g[Point(1i64, 1)], 9);
     }
 }

--- a/crates/python_2024/Cargo.toml
+++ b/crates/python_2024/Cargo.toml
@@ -6,7 +6,9 @@ rust-version.workspace = true
 publish = false
 
 [dependencies]
+paste.workspace = true
 pyo3 = { version = "0.29.0", features = ["abi3-py39"]}
+seq-macro.workspace = true
 year_2024.workspace = true
 
 [lints]

--- a/crates/python_2024/src/lib.rs
+++ b/crates/python_2024/src/lib.rs
@@ -3,233 +3,32 @@
 #![allow(clippy::implicit_clone)]
 
 use pyo3::prelude::*;
+use seq_macro::seq;
+
+// Generate `day_NN_a` / `day_NN_b` wrappers for every day instead of hand
+// writing all 50. `seq!` only pastes the counter as a suffix, so `paste!`
+// stitches it into the middle of the identifier.
+seq!(N in 01..=25 {
+    paste::paste! {
+        #[pyfunction]
+        fn [< day_~N _a >](input: &str) -> String {
+            year_2024::day_~N::solution_a(input).to_string()
+        }
+
+        #[pyfunction]
+        fn [< day_~N _b >](input: &str) -> String {
+            year_2024::day_~N::solution_b(input).to_string()
+        }
+    }
+});
 
 #[pymodule]
-pub mod aoc2024 {
-    use super::pyfunction;
-
-    #[pyfunction]
-    pub fn day_01_a(input: &str) -> String {
-        year_2024::day_01::solution_a(input).to_string()
-    }
-    #[pyfunction]
-    pub fn day_01_b(input: &str) -> String {
-        year_2024::day_01::solution_b(input).to_string()
-    }
-
-    #[pyfunction]
-    pub fn day_02_a(input: &str) -> String {
-        year_2024::day_02::solution_a(input).to_string()
-    }
-    #[pyfunction]
-    pub fn day_02_b(input: &str) -> String {
-        year_2024::day_02::solution_b(input).to_string()
-    }
-
-    #[pyfunction]
-    pub fn day_03_a(input: &str) -> String {
-        year_2024::day_03::solution_a(input).to_string()
-    }
-    #[pyfunction]
-    pub fn day_03_b(input: &str) -> String {
-        year_2024::day_03::solution_b(input).to_string()
-    }
-
-    #[pyfunction]
-    pub fn day_04_a(input: &str) -> String {
-        year_2024::day_04::solution_a(input).to_string()
-    }
-    #[pyfunction]
-    pub fn day_04_b(input: &str) -> String {
-        year_2024::day_04::solution_b(input).to_string()
-    }
-
-    #[pyfunction]
-    pub fn day_05_a(input: &str) -> String {
-        year_2024::day_05::solution_a(input).to_string()
-    }
-    #[pyfunction]
-    pub fn day_05_b(input: &str) -> String {
-        year_2024::day_05::solution_b(input).to_string()
-    }
-
-    #[pyfunction]
-    pub fn day_06_a(input: &str) -> String {
-        year_2024::day_06::solution_a(input).to_string()
-    }
-    #[pyfunction]
-    pub fn day_06_b(input: &str) -> String {
-        year_2024::day_06::solution_b(input).to_string()
-    }
-
-    #[pyfunction]
-    pub fn day_07_a(input: &str) -> String {
-        year_2024::day_07::solution_a(input).to_string()
-    }
-    #[pyfunction]
-    pub fn day_07_b(input: &str) -> String {
-        year_2024::day_07::solution_b(input).to_string()
-    }
-
-    #[pyfunction]
-    pub fn day_08_a(input: &str) -> String {
-        year_2024::day_08::solution_a(input).to_string()
-    }
-    #[pyfunction]
-    pub fn day_08_b(input: &str) -> String {
-        year_2024::day_08::solution_b(input).to_string()
-    }
-
-    #[pyfunction]
-    pub fn day_09_a(input: &str) -> String {
-        year_2024::day_09::solution_a(input).to_string()
-    }
-    #[pyfunction]
-    pub fn day_09_b(input: &str) -> String {
-        year_2024::day_09::solution_b(input).to_string()
-    }
-
-    #[pyfunction]
-    pub fn day_10_a(input: &str) -> String {
-        year_2024::day_10::solution_a(input).to_string()
-    }
-    #[pyfunction]
-    pub fn day_10_b(input: &str) -> String {
-        year_2024::day_10::solution_b(input).to_string()
-    }
-
-    #[pyfunction]
-    pub fn day_11_a(input: &str) -> String {
-        year_2024::day_11::solution_a(input).to_string()
-    }
-    #[pyfunction]
-    pub fn day_11_b(input: &str) -> String {
-        year_2024::day_11::solution_b(input).to_string()
-    }
-
-    #[pyfunction]
-    pub fn day_12_a(input: &str) -> String {
-        year_2024::day_12::solution_a(input).to_string()
-    }
-    #[pyfunction]
-    pub fn day_12_b(input: &str) -> String {
-        year_2024::day_12::solution_b(input).to_string()
-    }
-
-    #[pyfunction]
-    pub fn day_13_a(input: &str) -> String {
-        year_2024::day_13::solution_a(input).to_string()
-    }
-    #[pyfunction]
-    pub fn day_13_b(input: &str) -> String {
-        year_2024::day_13::solution_b(input).to_string()
-    }
-
-    #[pyfunction]
-    pub fn day_14_a(input: &str) -> String {
-        year_2024::day_14::solution_a(input).to_string()
-    }
-    #[pyfunction]
-    pub fn day_14_b(input: &str) -> String {
-        year_2024::day_14::solution_b(input).to_string()
-    }
-
-    #[pyfunction]
-    pub fn day_15_a(input: &str) -> String {
-        year_2024::day_15::solution_a(input).to_string()
-    }
-    #[pyfunction]
-    pub fn day_15_b(input: &str) -> String {
-        year_2024::day_15::solution_b(input).to_string()
-    }
-
-    #[pyfunction]
-    pub fn day_16_a(input: &str) -> String {
-        year_2024::day_16::solution_a(input).to_string()
-    }
-    #[pyfunction]
-    pub fn day_16_b(input: &str) -> String {
-        year_2024::day_16::solution_b(input).to_string()
-    }
-
-    #[pyfunction]
-    pub fn day_17_a(input: &str) -> String {
-        year_2024::day_17::solution_a(input).to_string()
-    }
-    #[pyfunction]
-    pub fn day_17_b(input: &str) -> String {
-        year_2024::day_17::solution_b(input).to_string()
-    }
-
-    #[pyfunction]
-    pub fn day_18_a(input: &str) -> String {
-        year_2024::day_18::solution_a(input).to_string()
-    }
-    #[pyfunction]
-    pub fn day_18_b(input: &str) -> String {
-        year_2024::day_18::solution_b(input).to_string()
-    }
-
-    #[pyfunction]
-    pub fn day_19_a(input: &str) -> String {
-        year_2024::day_19::solution_a(input).to_string()
-    }
-    #[pyfunction]
-    pub fn day_19_b(input: &str) -> String {
-        year_2024::day_19::solution_b(input).to_string()
-    }
-
-    #[pyfunction]
-    pub fn day_20_a(input: &str) -> String {
-        year_2024::day_20::solution_a(input).to_string()
-    }
-    #[pyfunction]
-    pub fn day_20_b(input: &str) -> String {
-        year_2024::day_20::solution_b(input).to_string()
-    }
-
-    #[pyfunction]
-    pub fn day_21_a(input: &str) -> String {
-        year_2024::day_21::solution_a(input).to_string()
-    }
-    #[pyfunction]
-    pub fn day_21_b(input: &str) -> String {
-        year_2024::day_21::solution_b(input).to_string()
-    }
-
-    #[pyfunction]
-    pub fn day_22_a(input: &str) -> String {
-        year_2024::day_22::solution_a(input).to_string()
-    }
-    #[pyfunction]
-    pub fn day_22_b(input: &str) -> String {
-        year_2024::day_22::solution_b(input).to_string()
-    }
-
-    #[pyfunction]
-    pub fn day_23_a(input: &str) -> String {
-        year_2024::day_23::solution_a(input).to_string()
-    }
-    #[pyfunction]
-    pub fn day_23_b(input: &str) -> String {
-        year_2024::day_23::solution_b(input).to_string()
-    }
-
-    #[pyfunction]
-    pub fn day_24_a(input: &str) -> String {
-        year_2024::day_24::solution_a(input).to_string()
-    }
-    #[pyfunction]
-    pub fn day_24_b(input: &str) -> String {
-        year_2024::day_24::solution_b(input).to_string()
-    }
-
-    #[pyfunction]
-    pub fn day_25_a(input: &str) -> String {
-        year_2024::day_25::solution_a(input).to_string()
-    }
-    #[pyfunction]
-    pub fn day_25_b(input: &str) -> String {
-        year_2024::day_25::solution_b(input).to_string()
-    }
+fn aoc2024(m: &Bound<'_, PyModule>) -> PyResult<()> {
+    seq!(N in 01..=25 {
+        paste::paste! {
+            m.add_function(wrap_pyfunction!([< day_~N _a >], m)?)?;
+            m.add_function(wrap_pyfunction!([< day_~N _b >], m)?)?;
+        }
+    });
+    Ok(())
 }

--- a/crates/year_2024/src/day_20.rs
+++ b/crates/year_2024/src/day_20.rs
@@ -69,11 +69,7 @@ pub fn solution_b(input: &str) -> Int {
 }
 
 pub fn main(_: bool) {
-    aoc::run(
-        "20",
-        |input| solution(input, 2, 100),
-        |input| solution(input, 20, 100),
-    );
+    aoc::run("20", solution_a, solution_b);
 }
 
 #[cfg(test)]


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Shared-library and bindings cleanup from the [review (#23)](https://github.com/henryiii/aoc2024/issues/23). Full-workspace `cargo clippy --all-targets --all-features -- -D warnings` and all tests pass.

- **python_2024** — replaced 234 lines of hand-written, near-identical `day_NN_a`/`day_NN_b` wrappers with a `seq!` + `paste!` generator over `01..=25` and a function-style `#[pymodule]` (the wasm crate already generates its bindings this way, and CLAUDE.md flagged these as "must be added manually"). `seq!` only pastes the counter as a suffix, so `paste!` stitches it into the middle of the identifier — the `day_NN_a`/`day_NN_b` Python names are unchanged. (Nothing in-repo imports the extension; the `python/2024/*.py` files are standalone.)
- **aoc::geom** — `Index<Point>` used `.ok().expect()` to dodge a trait bound while `IndexMut<Point>` used `.unwrap()` with an `Error: Debug` bound. Gave both the same bound so they read identically. Added a unit test for point indexing, since the crate sets `doctest = false` (the README is included as crate docs) and the worked example was never actually run.
- **day 20** — `main` re-specified the part closures; now passes `solution_a`/`solution_b` like every other day.

Refs #23.